### PR TITLE
Solucionar error "No se pudieron guardar las modificaciones"

### DIFF
--- a/registro/ISicres-Desktop-Web/src/main/webapp/scripts/frmdata.js
+++ b/registro/ISicres-Desktop-Web/src/main/webapp/scripts/frmdata.js
@@ -209,7 +209,7 @@ function cambioValor( Field )
 
 		var cantidad = FolderBarWnd.FldDataArr.length;
 
-		strValue = Field.value;
+		strValue = Field.getAttribute("value");
 
 		if (top.g_CopyFdr == 0){
 			FolderBarWnd.FldDataArr[cantidad] =
@@ -217,7 +217,7 @@ function cambioValor( Field )
 		}
 		/*Si estamos copiando un registro entonces no hay que meter en el array los campos vacios, solo los que tengan valor*/
 		else{
-			if (Field.value!=null && Field.value!="" && Field.getAttribute("FldId")!=null && Field.getAttribute("FldId")!=""){
+			if (Field.getAttribute("value")!=null && Field.getAttribute("value")!="" && Field.getAttribute("FldId")!=null && Field.getAttribute("FldId")!=""){
 				FolderBarWnd.FldDataArr[cantidad] =
 					 new FolderBarWnd.FldData( Field.getAttribute("FldId"), strValue, Field.name, Field.getAttribute("valueSust"));
 				FolderBarWnd.FldDataArr[cantidad].valueSust = top.getSustValue(Field.getAttribute("FldId"), document.getElementById("FrmData"));

--- a/sigem/SIGEM_CriptoValidacion/src/main/java/ieci/tecdoc/sgm/cripto/validacion/impl/bouncycastle/FnmtCertReader.java
+++ b/sigem/SIGEM_CriptoValidacion/src/main/java/ieci/tecdoc/sgm/cripto/validacion/impl/bouncycastle/FnmtCertReader.java
@@ -6,7 +6,7 @@ import java.security.cert.X509Certificate;
 
 public class FnmtCertReader implements IReaderCert {
 	
-	final static String CADENA = "OU=FNMT Clase 2 CA, O=FNMT, C=ES";
+    final static String CADENA = "FNMT";
     final static String CN_PERSONA_FISICA = "CN=NOMBRE ";
     final static String CN_PERSONA_JURIDICA = "CN=ENTIDAD ";
     final static String SEPARADOR = " - ";
@@ -82,7 +82,7 @@ public class FnmtCertReader implements IReaderCert {
 	}
 
 	public boolean isTypeOf(X509Certificate cert) {
-		return CADENA.equals(cert.getIssuerDN().toString());
+		return cert.getIssuerDN().toString().toLowerCase().contains(CADENA.toLowerCase());
 	}
 
 }


### PR DESCRIPTION
Corregido el método para leer el atributo "value" de un objeto mediante javascript. Hay que usar el método getAttribute en lugar de acceder directamente con obj.nombreAttributo.

Cuando se guarda un registro y se introducen remitentes (interesados) de forma libre en el textarea, los datos enviados recopilados mediante javascript incluyen la cadena "undefined" en lugar del valor "0#nombre del remitente##0". Esto genera una excepción al intentar interpretar esa cadena como un número entero, y no se guardan los datos del registro. Esto puede corregirse con un pequeño cambio en el código javascript.